### PR TITLE
Bugfix: missing leaflet dependency

### DIFF
--- a/widgets/package.json
+++ b/widgets/package.json
@@ -12,8 +12,8 @@
     "postinstall": "ngcc"
   },
   "dependencies": {
-    "primeng": "~12.2.3",
-    "primeicons": "~5.0.0"
+    "primeicons": "~5.0.0",
+    "primeng": "~12.2.3"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^12.2.13",
@@ -35,6 +35,7 @@
     "@ngx-translate/core": "~13.0.0",
     "@tb/custom-builder": "file:./builders",
     "codelyzer": "^6.0.2",
+    "leaflet": "^1.7.1",
     "ng-packagr": "12.2.6",
     "ngrx-store-freeze": "^0.2.4",
     "patch-package": "^6.4.7",

--- a/widgets/yarn.lock
+++ b/widgets/yarn.lock
@@ -5092,6 +5092,11 @@ klona@^2.0.4:
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.5.tgz#d166574d90076395d9963aa7a928fabb8d76afbc"
   integrity sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==
 
+leaflet@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.7.1.tgz#10d684916edfe1bf41d688a3b97127c0322a2a19"
+  integrity sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw==
+
 less-loader@10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/less-loader/-/less-loader-10.0.1.tgz#c05aaba68d00400820275f21c2ad87cb9fa9923f"


### PR DESCRIPTION
An error occurs when cloning the repo and running the commands:

- `cd widgets`
- `mvn clean install -P yarn-start`

Missing the `leaflet` package. Needed to run:

- `yarn add leaflet -D` in widgets directory