### PR TITLE
tslint.json - fix "extends" path

### DIFF
--- a/widgets/src/tslint.json
+++ b/widgets/src/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tslint.json",
+  "extends": "../tslint.json",
   "rules": {
     "directive-selector": [
       true,


### PR DESCRIPTION
Referencing `widgets/tslint.json` from `widgets/src/tslint.json`