### PR TITLE
Update custom-alarms-table-widget.component.ts

### DIFF
--- a/widgets/src/app/widgets/components/alarm/custom-alarms-table-widget.component.ts
+++ b/widgets/src/app/widgets/components/alarm/custom-alarms-table-widget.component.ts
@@ -112,7 +112,7 @@ interface AlarmWidgetActionDescriptor extends WidgetActionDescriptor {
   clear?: boolean;
 }
 
-const cssjs = (window as any).ccsjs;
+const cssjs = (window as any).cssjs;
 
 @Component({
   selector: 'tb-custom-alarms-table-widget',


### PR DESCRIPTION
Fix a typo which leads to an error when someone is trying to use the custom-alarms-table widget:
3125.8cfc31e492bb434c.js:1 TypeError: zB is not a constructor
    at GB.initializeConfig (custom-alarms-table-widget.component.mjs:388:27)
    at GB.ngOnInit (custom-alarms-table-widget.component.mjs:285:14)
    
![image](https://github.com/thingsboard/thingsboard-extensions/assets/1839663/1d352574-89df-48b1-bab1-ee77ce15aef9)
![image](https://github.com/thingsboard/thingsboard-extensions/assets/1839663/c40a24e7-8f53-43e3-9b78-292ce6ade037)
